### PR TITLE
Update key used to validate keycloak password

### DIFF
--- a/pkg/controller/syncer/keycloak.go
+++ b/pkg/controller/syncer/keycloak.go
@@ -85,7 +85,7 @@ func (k *KeycloakSyncer) Validate() error {
 		}
 
 		// Password key validation
-		if _, found := credentialsSecret.Data[secretUsernameKey]; !found {
+		if _, found := credentialsSecret.Data[secretPasswordKey]; !found {
 			validationErrors = append(validationErrors, fmt.Errorf("Could not find 'password' key in secret '%s' in namespace '%s", k.Provider.CredentialsSecret.Name, k.Provider.CredentialsSecret.Namespace))
 		}
 


### PR DESCRIPTION
It looks like while doing validation of the credentials for keycloak, that `secretUsernameKey` is used for validating both the username and password. This PR changes the password check to use `secretPasswordKey` which seems more appropriate.