### PR TITLE
Corrected username for Azure provider

### DIFF
--- a/pkg/controller/syncer/azure.go
+++ b/pkg/controller/syncer/azure.go
@@ -183,7 +183,7 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 		ocpGroup.GetAnnotations()[constants.SyncSourceUID] = *cachedGroup.ObjectID
 
 		for _, user := range a.CachedGroupUsers[*cachedGroup.ObjectID] {
-			ocpGroup.Users = append(ocpGroup.Users, *user.DisplayName)
+			ocpGroup.Users = append(ocpGroup.Users, *user.UserPrincipalName)
 		}
 
 		ocpGroups = append(ocpGroups, ocpGroup)


### PR DESCRIPTION
Corrected username for Azure provider to use `UserPrincipalName` to resolve #25 