### PR TITLE
Manage keycloak items returned

### DIFF
--- a/controllers/groupsync_controller.go
+++ b/controllers/groupsync_controller.go
@@ -147,8 +147,8 @@ func (r *GroupSyncReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			if group.GetLabels() != nil {
 				ocpGroupLabels = group.GetLabels()
 			}
-			ocpGroup.SetLabels(ocpGroupLabels)
-			ocpGroup.SetAnnotations(ocpGroupAnnotations)
+			ocpGroup.SetLabels(mergeMap(ocpGroup.GetLabels(), ocpGroupLabels))
+			ocpGroup.SetAnnotations(mergeMap(ocpGroup.GetAnnotations(), ocpGroupAnnotations))
 
 			// Add Label for new resource
 			ocpGroup.Labels[constants.SyncProvider] = providerLabel
@@ -244,4 +244,19 @@ func ISO8601(t time.Time) string {
 	}
 	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s",
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), tz)
+}
+
+func mergeMap(m1, m2 map[string]string) map[string]string {
+
+	if m1 != nil {
+		for mKey, mValue := range m2 {
+			m1[mKey] = mValue
+		}
+
+		return m1
+
+	} else {
+		return m2
+	}
+
 }

--- a/go.sum
+++ b/go.sum
@@ -704,6 +704,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
@@ -837,6 +838,7 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=


### PR DESCRIPTION
Changes to aid in managing the number of items returned from Keycloak

In addition, also aid in retaining labels and annotations from that are on groups in OpenShift

Resolves #43 #39 