### PR TITLE
Fix semantic versioning control with standard from https://semver.org

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,8 +15,8 @@ jobs:
           QUAY_REGISTRY: ${{ secrets.QUAY_REGISTRY }}
         run: |
           DEFAULT_QUAY_REGISTRY=${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY)
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-DEFAULT_QUAY_REGISTRY}" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" |tee -a $GITHUB_ENV
+          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-DEFAULT_QUAY_REGISTRY}" |tee -a $GITHUB_ENV
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -34,7 +34,7 @@ jobs:
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
           mkdir ${HOME}/bin
           mv operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu ${HOME}/bin/operator-sdk 
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          echo "${HOME}/bin" |tee -a $GITHUB_PATH
 
       - name: Download compatible Helm version
         shell: bash

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,8 +18,8 @@ jobs:
           QUAY_REGISTRY: ${{ secrets.QUAY_REGISTRY }}
         run: |
           DEFAULT_QUAY_REGISTRY=${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY)
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" |tee -a $GITHUB_ENV
+          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" |tee -a $GITHUB_ENV
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -37,7 +37,7 @@ jobs:
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
           mkdir ${HOME}/bin
           mv operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu ${HOME}/bin/operator-sdk
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          echo "${HOME}/bin" |tee -a $GITHUB_PATH
 
       - name: Download compatible Helm version
         shell: bash
@@ -53,13 +53,14 @@ jobs:
         if: "startsWith(github.ref, 'refs/tags')"
         shell: bash
         run: |
-          echo "OPERATOR_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-          echo "BUNDLE_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" |tee -a $GITHUB_ENV
+          echo "BUNDLE_IMAGE_TAG=${GITHUB_REF/refs\/tags\//}" |tee -a $GITHUB_ENV
           export TAG=${GITHUB_REF/refs\/tags\//}
-          echo "BUNDLE_VERSION=${TAG:1}" >> $GITHUB_ENV
-          export SEMVER_COMPLIANT=$(echo ${TAG:1} | egrep '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-])(?:\.(?:0|[1-9]\d|\d*[a-zA-Z-][0-9a-zA-Z-]))))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
+          echo "BUNDLE_VERSION=${TAG:1}" |tee -a $GITHUB_ENV
+          # Checking Semantic Versioning using official guide here: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string .
+          SEMANTICREGEX='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          export SEMVER_COMPLIANT=$(echo ${TAG:1} | grep -Po $SEMANTICREGEX)
           if [ -z "$SEMVER_COMPLIANT" ]; then   echo "invalid semver tag ${GITHUB_REF/refs\/tags\//}"; exit 1; fi
-
       - name: Get most recent tag
         uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
@@ -80,9 +81,9 @@ jobs:
         shell: bash
         run: |
           export BUNDLE_VERSION=${{ steps.bump-semver.outputs.new_version }}
-          echo "OPERATOR_IMAGE_TAG=latest" >> $GITHUB_ENV
-          echo "BUNDLE_IMAGE_TAG=latest" >> $GITHUB_ENV
-          echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE_TAG=latest" |tee -a $GITHUB_ENV
+          echo "BUNDLE_IMAGE_TAG=latest" |tee -a $GITHUB_ENV
+          echo "BUNDLE_VERSION=${BUNDLE_VERSION:1}" |tee -a $GITHUB_ENV
 
       - name: build code
         run: make
@@ -146,8 +147,8 @@ jobs:
           QUAY_REGISTRY: ${{ secrets.QUAY_REGISTRY }}
         run: |
           DEFAULT_QUAY_REGISTRY=${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY)
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" |tee -a $GITHUB_ENV
+          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" |tee -a $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -163,7 +164,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" |tee -a $GITHUB_ENV
 
       - name: Configure Git
         shell: bash
@@ -193,7 +194,7 @@ jobs:
       - name: set repo name
         shell: bash
         run: |
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" |tee -a $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -201,7 +202,7 @@ jobs:
           git fetch --prune --unshallow
       - name: Get the version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" |tee -a $GITHUB_ENV
       - name: Generate Changelog
         run: |
           LATEST_TAG=$(git tag --sort=creatordate | sed '$!d')
@@ -234,8 +235,8 @@ jobs:
           QUAY_REGISTRY: ${{ secrets.QUAY_REGISTRY }}
         run: |
           DEFAULT_QUAY_REGISTRY=${{ github.repository_owner }}/$(basename $GITHUB_REPOSITORY)
-          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" >> $GITHUB_ENV
+          echo "REPOSITORY_NAME=$(basename $GITHUB_REPOSITORY)" |tee -a $GITHUB_ENV
+          echo "QUAY_REGISTRY=${QUAY_REGISTRY:-$DEFAULT_QUAY_REGISTRY}" |tee -a $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -252,12 +253,12 @@ jobs:
           chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
           mkdir ${HOME}/bin
           mv operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu ${HOME}/bin/operator-sdk
-          echo "${HOME}/bin" >> $GITHUB_PATH
+          echo "${HOME}/bin" |tee -a $GITHUB_PATH
       - name: Get the version
         id: get_version
         run: |
           export TAG=${GITHUB_REF/refs\/tags\//}
-          echo "VERSION=${TAG:1}" >> $GITHUB_ENV
+          echo "VERSION=${TAG:1}" |tee -a $GITHUB_ENV
       - name: checkout community-operators
         uses: actions/checkout@v2
         with:
@@ -267,7 +268,7 @@ jobs:
       - name: check whether it is first release
         shell: bash
         run: |
-          echo first_release=$([[ ! -d "./tmp/community-operators/community-operators/$(basename $GITHUB_REPOSITORY)" ]] && echo 'true' || echo 'false') >> $GITHUB_ENV
+          echo first_release=$([[ ! -d "./tmp/community-operators/community-operators/$(basename $GITHUB_REPOSITORY)" ]] && echo 'true' || echo 'false') |tee -a $GITHUB_ENV
           echo $first_release
 
       - name: create and copy bundle to community operators


### PR DESCRIPTION
Fixing the semantic versioning as it won't work from version v0.0.10 because egrep doesn't use the perl regex correctly.
As I was already looking at the code I've found that [semver.org](https://semver.org) has a really good regex already bilt.

Also I've moved the `>>` to `|tee -a` to simplify debugging.