### PR TITLE
Add support for more than 20 Okta groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ The following table describes the set of configuration options for the Okta prov
 | `appId` | Application ID of App Groups are assigned to | `''`  | Yes |
 | `extractLoginUsername` | Bool to determine if you should extract username from okta login | `false`  | No |
 | `profileKey` | Attribute field on Okta User Profile you would like to use as identity | `'login'` | No |
+| `groupLimit` | Integer to set the maximum number of groups to sync | `1000` | No |
 
 
 The following is an example of a minimal configuration that can be applied to integrate with an Okta provider:

--- a/api/v1alpha1/groupsync_types.go
+++ b/api/v1alpha1/groupsync_types.go
@@ -360,6 +360,10 @@ type OktaProvider struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Profile Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// +kubebuilder:validation:Optional
 	ProfileKey string `json:"profileKey"`
+	// GroupLimit is the maximum number of groups that can be synced. Default is "1000"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Limit",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	// +kubebuilder:validation:Optional
+	GroupLimit int `json:"groupLimit"`
 }
 
 // SecretRef represents a reference to an item within a Secret

--- a/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
@@ -549,6 +549,9 @@ spec:
                           url:
                             description: URL is the location of the Okta domain server
                             type: string
+                          groupLimit:
+                            description: The maximum number of groups that can be synced
+                            type: integer
                         required:
                           - appId
                           - credentialsSecret


### PR DESCRIPTION
There was an issue with the Okta syncer due to the way the API call was made and how the client returned the groups in pages. This fix makes the number of groups the syncer can pull customizable with a default of 1000. Fixes issue #105 