### PR TITLE
Do not sync okta users who are not ACTIVE

### DIFF
--- a/pkg/syncer/okta.go
+++ b/pkg/syncer/okta.go
@@ -30,6 +30,7 @@ var (
 const (
 	// API token given by Okta application
 	secretOktaTokenKey = "okta-api-token"
+	activeStatus       = "ACTIVE"
 )
 
 type OktaSyncer struct {
@@ -157,13 +158,15 @@ func (o *OktaSyncer) Sync() ([]userv1.Group, error) {
 		users := o.cachedGroupMembers[cachedGroup.Id]
 		for _, user := range users {
 			profile := *user.Profile
-			if userName, ok := profile[o.Provider.ProfileKey].(string); !ok {
-				oktaLogger.Info("attribute unavailable on okta user profile " + o.Provider.ProfileKey)
-			} else if o.Provider.ExtractLoginUsername {
-				userName = strings.Split(userName, "@")[0]
-				ocpGroup.Users = append(ocpGroup.Users, userName)
-			} else {
-				ocpGroup.Users = append(ocpGroup.Users, userName)
+			if user.Status == activeStatus {
+				if userName, ok := profile[o.Provider.ProfileKey].(string); !ok {
+					oktaLogger.Info("attribute unavailable on okta user profile " + o.Provider.ProfileKey)
+				} else if o.Provider.ExtractLoginUsername {
+					userName = strings.Split(userName, "@")[0]
+					ocpGroup.Users = append(ocpGroup.Users, userName)
+				} else {
+					ocpGroup.Users = append(ocpGroup.Users, userName)
+				}
 			}
 		}
 		ocpGroups = append(ocpGroups, ocpGroup)


### PR DESCRIPTION
Our organization has a large number of "Deactivated" users which are still in groups and get synced.

This change only syncs users with "ACTIVE" status.

Fixes #124 