### PR TITLE
Revert + improvements to WATCH_NAMESPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,32 @@ spec:
 
 If a schedule is not provided, synchronization will occur only when the object is reconciled by the platform.
 
+## Accessing Secrets and ConfigMaps in Other Namespaces
+
+By default, the operator monitors resources in the namespace that it has been deployed within. This is defined by setting the `WATCH_NAMESPACE` environment variable. Support is available for accessing ConfigMaps and Secrets in other namespaces so that existing resources may be utilized as desired.
+
+To enable the operator to access resources across multiple, set the environment variable with a comma separate list of namespaces that include the namespace the operator is deployed within and any additional namespaces that are desired.
+
+To make use of this feature when deploying through the Operator Lifecycle Manager, set the following configuration on the `Subscription` resource:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: group-sync-operator
+  namespace: group-sync-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: group-sync-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: WATCH_NAMESPACE
+        value: "<comma separated list of namespaces>"
+```
+
 ## Deploying the Operator
 
 This is a namespace level operator that you can deploy in any namespace. However, `group-sync-operator` is recommended.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -28,6 +28,11 @@ spec:
             - "--health-probe-bind-address=:8081"
             - "--metrics-addr=127.0.0.1:8080"
             - "--leader-elect"
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       volumes:
         - name: tls-cert
           secret:

--- a/config/helmchart/templates/_helpers.tpl
+++ b/config/helmchart/templates/_helpers.tpl
@@ -69,3 +69,14 @@ Create the image path for the passed in image field
 {{- printf "%s:%s" .repository .version -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Check if WATCH_NAMESPACE environment variable has been provided
+*/}}
+{{- define "group-sync-operator.checkWatchNamespace" -}}
+{{- range .Values.env -}}
+{{- if eq .name "WATCH_NAMESPACE" -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -55,12 +55,16 @@ spec:
           image: "{{ template "group-sync-operator.image" .Values.image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}
-          {{- if .Values.env }}
           env:
+            {{- if eq (include "group-sync-operator.checkWatchNamespace" .) ""  }}
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,11 @@ spec:
             requests:
               cpu: 300m
               memory: 200Mi
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
@@ -40,6 +40,11 @@ spec:
       - description: Azure represents the Azure provider
         displayName: Azure Provider
         path: providers[0].azure
+      - description: AuthorityHost is the location of the Azure Active Directory endpoint
+        displayName: Azure URL
+        path: providers[0].azure.authorityHost
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: BaseGroups allows for a set of groups to be specified to start
           searching from instead of searching all groups in the directory
         displayName: Base Groups
@@ -90,22 +95,18 @@ spec:
         path: providers[0].azure.insecure
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: URL is the location of the Azure platform
-        displayName: Azure URL
-        path: providers[0].azure.url
+      - description: Prune Whether to prune groups that are no longer in Azure. Default
+          is false
+        displayName: Prune
+        path: providers[0].azure.prune
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: UserNameAttributes are the fields to consider on the User object
           containing the username
         displayName: Azure UserName Attributes
         path: providers[0].azure.userNameAttributes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in Azure. Default is false
-        displayName: Azure Prune
-        path: providers[0].azure.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: GitHub represents the GitHub provider
         displayName: GitHub Provider
         path: providers[0].github
@@ -207,6 +208,12 @@ spec:
         path: providers[0].github.organization
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Prune Whether to prune groups that are no longer in GitHub. Default
+          is false
+        displayName: Prune
+        path: providers[0].github.prune
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Teams represents a filtered list of teams to synchronize
         displayName: Teams to Synchronize
         path: providers[0].github.teams
@@ -222,11 +229,6 @@ spec:
         path: providers[0].github.v4url
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in GitHub. Default is false
-        displayName: GitHub Prune
-        path: providers[0].github.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: GitLab represents the GitLab provider
         displayName: GitLab Provider
         path: providers[0].gitlab
@@ -322,16 +324,17 @@ spec:
         path: providers[0].gitlab.insecure
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Prune Whether to prune groups that are no longer in GitLab. Default
+          is false
+        displayName: Prune
+        path: providers[0].gitlab.prune
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: URL is the location of the GitLab server
         displayName: GitLab URL
         path: providers[0].gitlab.url
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in GitLab. Default is false
-        displayName: GitLab Prune
-        path: providers[0].gitlab.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Keycloak represents the Keycloak provider
         displayName: Keycloak Provider
         path: providers[0].keycloak
@@ -428,6 +431,12 @@ spec:
       - description: LoginRealm is the Keycloak realm to authenticate against
         displayName: Realm to Login Against
         path: providers[0].keycloak.loginRealm
+      - description: Prune Whether to prune groups that are no longer in Keycloak.
+          Default is false
+        displayName: Prune
+        path: providers[0].keycloak.prune
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Realm is the realm containing the groups to synchronize against
         displayName: Realm to Synchronize
         path: providers[0].keycloak.realm
@@ -441,11 +450,6 @@ spec:
         path: providers[0].keycloak.url
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in Keycloak. Default is false
-        displayName: Keycloak Prune
-        path: providers[0].keycloak.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Ldap represents the LDAP provider
         displayName: LDAP Provider
         path: providers[0].ldap
@@ -553,6 +557,12 @@ spec:
         path: providers[0].ldap.insecure
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Prune Whether to prune groups that are no longer in LDAP. Default
+          is false
+        displayName: Prune
+        path: providers[0].ldap.prune
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: RFC2307Config represents the configuration for a RFC2307 schema
         displayName: RFC2307 configuration
         path: providers[0].ldap.rfc2307
@@ -566,11 +576,6 @@ spec:
         path: providers[0].ldap.whitelist
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in LDAP. Default is false
-        displayName: LDAP Prune
-        path: providers[0].ldap.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Name represents the name of the provider
         displayName: Name of the Provider
         path: providers[0].name
@@ -615,8 +620,9 @@ spec:
         path: providers[0].okta.extractLoginUsername
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: GroupLimit is the maximum number of groups that are requested from OKTA per request.  Multiple requests will be made using pagination if you have more groups than this limit.
-          Default is "1000"
+      - description: GroupLimit is the maximum number of groups that are requested
+          from OKTA per request.  Multiple requests will be made using pagination
+          if you have more groups than this limit. Default is "1000"
         displayName: Group Limit
         path: providers[0].okta.groupLimit
         x-descriptors:
@@ -632,16 +638,17 @@ spec:
         path: providers[0].okta.profileKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Prune Whether to prune groups that are no longer in OKTA. Default
+          is false
+        displayName: Prune
+        path: providers[0].okta.prune
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: URL is the location of the Okta domain server
         displayName: Okta URL
         path: providers[0].okta.url
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Prune Whether to prune groups that are no longer in OKTA. Default is false
-        displayName: OKTA Prune
-        path: providers[0].okta.prune
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Schedule represents a cron based configuration for synchronization
         displayName: Schedule
         path: schedule

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/controllers/groupsync_controller.go
+++ b/controllers/groupsync_controller.go
@@ -51,6 +51,7 @@ type GroupSyncReconciler struct {
 // +kubebuilder:rbac:groups=redhatcop.redhat.io,resources=groupsyncs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *GroupSyncReconciler) Reconcile(context context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("groupsync", req.NamespacedName)


### PR DESCRIPTION
Revert changes to `WATCH_NAMESPACE` to confirm to existing functionality, but support users who want to watch multiple namespaces

* General CSV health updates
* Reimplement `WATCH_NAMESPACE` logic
* Updated documentation

Resolves #237 