### PR TITLE
Add delay to prevent unexpected groups being pruned

### DIFF
--- a/controllers/groupsync_controller.go
+++ b/controllers/groupsync_controller.go
@@ -177,6 +177,8 @@ func (r *GroupSyncReconciler) Reconcile(context context.Context, req ctrl.Reques
 		}
 
 		if groupSyncer.GetPrune() {
+			// Allow time for the last group annotation to be synced before starting to prune
+			time.Sleep(time.Second * 1)
 			logger.Info("Start Pruning Groups")
 			prunedGroups, err = r.pruneGroups(context, instance, providerLabel, syncStartTime, logger)
 			if err != nil {


### PR DESCRIPTION
Related to the following issues:
https://github.com/redhat-cop/group-sync-operator/issues/248
https://github.com/redhat-cop/group-sync-operator/issues/169

Bug: Groups are pruned unexpectedly

Cause: The OpenShift group annotation is not seen as updated when the prune runs.
`if group.Annotations[constants.SyncTimestamp] < syncStartTime`
There is a potential race condition where the group object annotation has not updated when it evaluates which groups need to be pruned. In this case, the syncTimestamp is not seen as updated and will be < the syncStartTime.

Workaround: Add a delay when pruning is to start to allow time for the objects to be updated. This workaround isn't a pretty solution and introduces latency into the operation.