### PR TITLE
request to change function ListAllGroupMembers to ListGroupMembers 

### DIFF
--- a/pkg/syncer/gitlab.go
+++ b/pkg/syncer/gitlab.go
@@ -311,7 +311,7 @@ func (g *GitLabSyncer) getGroupMembers(groupId int) ([]*gitlab.GroupMember, erro
 	}
 
 	for {
-		members, resp, err := g.Client.Groups.ListAllGroupMembers(groupId, opt)
+		members, resp, err := g.Client.Groups.ListGroupMembers(groupId, opt)
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Background issue: https://github.com/redhat-cop/group-sync-operator/issues/219

Requesting to change this function from ListAllGroupMembers to ListGroupMembers. 

Current issue is that we are able to use Gitlab subgroups, but currently returns a list of group members including inherited members through ancestor groups. https://github.com/xanzy/go-gitlab/blob/master/group_members.go#L97 

Example groupsync:

```yaml 
groups: 
   - subgroup1
```

Gitlab structure:

Group1
- User1
- User2 
- Subgroup1 
    - User3
    - User4 
 
```
oc get group subgroup1 
user1,user2,user3,user4
```

Really, we want list just the member of the subgroups and append to groupMembers variable. ListGroupMembers gets a list of group members. Inherited members through ancestor groups are not included therefore, group syncing can become more granular. https://github.com/xanzy/go-gitlab/blob/master/group_members.go#L71 

Example groupsync:

```yaml
groups: 
   - subgroup1
```

Gitlab structure:

Group1
- User1
- User2 
- Subgroup1 
    - User3
    - User4 
 
```
oc get group subgroup1 
user3,user4
```
