### PR TITLE
Configure scope for GitLab provider

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@v1.0.4
+    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@v1.0.5
     with:
       GO_VERSION: ~1.18
       RUN_UNIT_TESTS: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@v1.0.4
+    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@v1.0.5
     secrets:
       COMMUNITY_OPERATOR_PAT: ${{ secrets.COMMUNITY_OPERATOR_PAT }}
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/api/v1alpha1/groupsync_types.go
+++ b/api/v1alpha1/groupsync_types.go
@@ -270,25 +270,31 @@ type GitLabProvider struct {
 	// +kubebuilder:validation:Required
 	CredentialsSecret *ObjectRef `json:"credentialsSecret"`
 
-	// Insecure specifies whether to allow for unverified certificates to be used when communicating to GitLab
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ignore SSL Verification",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// +kubebuilder:validation:Optional
-	Insecure bool `json:"insecure,omitempty"`
-
 	// Groups represents a filtered list of groups to synchronize
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Groups to Synchronize",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// +kubebuilder:validation:Optional
 	Groups []string `json:"groups,omitempty"`
 
-	// URL is the location of the GitLab server
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GitLab URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// Insecure specifies whether to allow for unverified certificates to be used when communicating to GitLab
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ignore SSL Verification",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +kubebuilder:validation:Optional
-	URL *string `json:"url,omitempty"`
+	Insecure bool `json:"insecure,omitempty"`
 
 	// Prune Whether to prune groups that are no longer in GitLab. Default is false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Prune",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +kubebuilder:validation:Optional
 	Prune bool `json:"prune"`
+
+	// Scope represents the depth for which groups will be synchronized
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scope to synchronize against"
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=one;sub
+	Scope SyncScope `json:"scope,omitempty"`
+
+	// URL is the location of the GitLab server
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GitLab URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +kubebuilder:validation:Optional
+	URL *string `json:"url,omitempty"`
 }
 
 // LdapProvider represents integration with an LDAP server

--- a/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
@@ -320,6 +320,12 @@ spec:
                           prune:
                             description: Prune Whether to prune groups that are no longer in GitLab. Default is false
                             type: boolean
+                          scope:
+                            description: Scope represents the depth for which groups will be synchronized
+                            enum:
+                              - one
+                              - sub
+                            type: string
                           url:
                             description: URL is the location of the GitLab server
                             type: string

--- a/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
@@ -384,6 +384,9 @@ spec:
         path: providers[0].gitlab.prune
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Scope represents the depth for which groups will be synchronized
+        displayName: Scope to synchronize against
+        path: providers[0].gitlab.scope
       - description: URL is the location of the GitLab server
         displayName: GitLab URL
         path: providers[0].gitlab.url


### PR DESCRIPTION
Enabled the ability to leverage both single scope and sub scope for retrieving GitLab group members

Related to #253 