### PR TITLE
Correct logic for parsing and comparing sync time

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -10,5 +10,4 @@ const (
 	HierarchyChildren = "hierarchy_children"
 	HierarchyParent   = "hierarchy_parent"
 	HierarchyParents  = "hierarchy_parents"
-	ISO8601Layout     = "2006-01-02T15:04:05Z0700"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -10,4 +10,5 @@ const (
 	HierarchyChildren = "hierarchy_children"
 	HierarchyParent   = "hierarchy_parent"
 	HierarchyParents  = "hierarchy_parents"
+	ISO8601Layout     = "2006-01-02T15:04:05Z0700"
 )

--- a/pkg/provider/ldap/helpers/groupsyncer.go
+++ b/pkg/provider/ldap/helpers/groupsyncer.go
@@ -172,19 +172,7 @@ func (s *LDAPGroupSyncer) makeOpenShiftGroup(ldapGroupUID string, usernames []st
 
 	// overwrite Group Users data
 	group.Users = usernames
-	group.Annotations[LDAPSyncTimeAnnotation] = ISO8601(time.Now())
+	group.Annotations[LDAPSyncTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
 
 	return group, nil
-}
-
-// ISO8601 returns an ISO 6801 formatted string from a time.
-func ISO8601(t time.Time) string {
-	var tz string
-	if zone, offset := t.Zone(); zone == "UTC" {
-		tz = "Z"
-	} else {
-		tz = fmt.Sprintf("%03d00", offset/3600)
-	}
-	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s",
-		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), tz)
 }


### PR DESCRIPTION
Existing logic for determining when to prune groups was based on string comparison instead of proper datetime formatting. This enhancement corrects this logic.

Related to the following:

#248
#69

Mitigates the need for #251 