### PR TITLE
Azure userattr nil fix

### DIFF
--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -438,6 +438,8 @@ func (a *AzureSyncer) isUsernamePresent(value reflect.Value, field string) (stri
 
 		if !attr.IsNil() {
 			return fmt.Sprintf("%s", attr.Elem().Interface()), true
+		} else {
+			azureLogger.Info(fmt.Sprintf("Warning: Skipping User record with empty %s.", field))
 		}
 	}
 

--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -433,7 +433,12 @@ func (a *AzureSyncer) isUsernamePresent(value reflect.Value, field string) (stri
 	method := value.MethodByName(fmt.Sprintf("Get%s", caser.String(field)))
 
 	if method.IsValid() {
-		return fmt.Sprintf("%s", method.Call(nil)[0].Elem().Interface()), true
+
+		attr := method.Call(nil)[0]
+
+		if !attr.IsNil() {
+			return fmt.Sprintf("%s", attr.Elem().Interface()), true
+		}
 	}
 
 	return "", false


### PR DESCRIPTION
Fixes #268 

The logic that checks if a username is present in the group when a userNameAttribute is set does not guard against nil values, it only checks if the reflected method call would be valid. This results in calling .Interface() on a nil value which crashes the operator.

This PR fixes this issue by explicitly checking if the reflected value is nil before calling .Elem().Interface(). If it is nil, it simply returns false, as was the original logic.

This also adds some preliminary logging at least alerting users that they are hitting this issue,... unfortunately, in my tests, the user object retrieved from the Graph API had a UPN that was also nil, so the logging does not specify _which_ user had the problem. This points to the fact that there may be a deeper underlying issue,... (or something I do not understand)

Nevertheless, this at least fixes the crash and alerts the user to an issue.