### PR TITLE
Move to go 1.21.x

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,5 +9,5 @@ jobs:
     name: shared-operator-workflow
     uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@v1.0.5
     with:
-      GO_VERSION: ~1.18
+      GO_VERSION: ~1.21
       RUN_UNIT_TESTS: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,5 +16,5 @@ jobs:
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
     with:
       PR_ACTOR: "andy.block@gmail.com"
-      GO_VERSION: ~1.18
+      GO_VERSION: ~1.21
       RUN_UNIT_TESTS: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-cop/group-sync-operator
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.4.0


### PR DESCRIPTION
Maybe most of the other dependency upgrades should go in as well?