### PR TITLE
ci: use latest workflow versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@v1.0.7
+    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@main
     with:
       GO_VERSION: ~1.21
       RUN_UNIT_TESTS: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@1.0.8
+    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@v1.0.8
     with:
       GO_VERSION: ~1.21
       RUN_UNIT_TESTS: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@main
+    uses: redhat-cop/github-workflows-operators/.github/workflows/pr-operator.yml@1.0.8
     with:
       GO_VERSION: ~1.21
       RUN_UNIT_TESTS: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@1.0.8
+    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@v1.0.8
     secrets:
       COMMUNITY_OPERATOR_PAT: ${{ secrets.COMMUNITY_OPERATOR_PAT }}
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@main
+    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@1.0.8
     secrets:
       COMMUNITY_OPERATOR_PAT: ${{ secrets.COMMUNITY_OPERATOR_PAT }}
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   shared-operator-workflow:
     name: shared-operator-workflow
-    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@v1.0.7
+    uses: redhat-cop/github-workflows-operators/.github/workflows/release-operator.yml@main
     secrets:
       COMMUNITY_OPERATOR_PAT: ${{ secrets.COMMUNITY_OPERATOR_PAT }}
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
Use the latest version of the GitHub workflows so that we can use rate limiting fix for Trivy. A new tag is not available so using `main` for now; a specific tag can be set when one comes available. See [this comment](https://github.com/orgs/community/discussions/139074#discussioncomment-11301306) for further info.