### PR TITLE
okta: use strings.Cut for username extraction

### DIFF
--- a/pkg/syncer/okta.go
+++ b/pkg/syncer/okta.go
@@ -163,7 +163,7 @@ func (o *OktaSyncer) Sync() ([]userv1.Group, error) {
 				if userName, ok := profile[o.Provider.ProfileKey].(string); !ok {
 					oktaLogger.Info("attribute unavailable on okta user profile " + o.Provider.ProfileKey)
 				} else if o.Provider.ExtractLoginUsername {
-					userName = strings.Split(userName, "@")[0]
+					userName, _, _ = strings.Cut(userName, "@")
 					ocpGroup.Users = append(ocpGroup.Users, userName)
 				} else {
 					ocpGroup.Users = append(ocpGroup.Users, userName)


### PR DESCRIPTION
In the use case here, we only need the portion of the string before the `@` symbol (if present); the remaining portions can be discarded. `strings.Cut` is preferable over `strings.Split` in this case since `strings.Split` needs to allocate a slice, while `strings.Cut` essentially returns the substring portion of the original string.

This is not a big bottleneck, but the username extraction occurs for every active user of every group on every sync, so it still results in a lot of little allocations that need to be GCed later.

Benchmark result:
```
goos: darwin
goarch: arm64
pkg: github.com/redhat-cop/group-sync-operator/pkg/syncer
cpu: Apple M4 Pro
BenchmarkUsernameExtraction_Split/simple_email-14         	45820909	        26.11 ns/op	      32 B/op	       1 allocs/op
BenchmarkUsernameExtraction_Split/long_email-14           	40596657	        29.59 ns/op	      32 B/op	       1 allocs/op
BenchmarkUsernameExtraction_Split/short_email-14          	53409392	        22.34 ns/op	      32 B/op	       1 allocs/op
BenchmarkUsernameExtraction_Split/no_at_sign-14           	62488608	        19.06 ns/op	      16 B/op	       1 allocs/op
BenchmarkUsernameExtraction_Split/multiple_at-14          	38007007	        32.13 ns/op	      48 B/op	       1 allocs/op
BenchmarkUsernameExtraction_Cut/simple_email-14           	406243166	         2.965 ns/op	       0 B/op	       0 allocs/op
BenchmarkUsernameExtraction_Cut/long_email-14             	368027271	         3.230 ns/op	       0 B/op	       0 allocs/op
BenchmarkUsernameExtraction_Cut/short_email-14            	404018865	         3.020 ns/op	       0 B/op	       0 allocs/op
BenchmarkUsernameExtraction_Cut/no_at_sign-14             	368708479	         3.239 ns/op	       0 B/op	       0 allocs/op
BenchmarkUsernameExtraction_Cut/multiple_at-14            	405093487	         2.976 ns/op	       0 B/op	       0 allocs/op
```

<details>
<summary>Benchmark code</summary>

```go
package syncer

import (
	"strings"
	"testing"
)

func BenchmarkUsernameExtraction_Split(b *testing.B) {
	testCases := []struct {
		name     string
		username string
	}{
		{"simple_email", "user@example.com"},
		{"long_email", "firstname.lastname.verylongusername@subdomain.example.com"},
		{"short_email", "a@b.c"},
		{"no_at_sign", "plainusername"},
		{"multiple_at", "user@domain@extra"},
	}

	for _, tc := range testCases {
		b.Run(tc.name, func(b *testing.B) {
			var result string
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				parts := strings.Split(tc.username, "@")
				result = parts[0]
			}
			_ = result // Prevent compiler optimization
		})
	}
}

func BenchmarkUsernameExtraction_Cut(b *testing.B) {
	testCases := []struct {
		name     string
		username string
	}{
		{"simple_email", "user@example.com"},
		{"long_email", "firstname.lastname.verylongusername@subdomain.example.com"},
		{"short_email", "a@b.c"},
		{"no_at_sign", "plainusername"},
		{"multiple_at", "user@domain@extra"},
	}

	for _, tc := range testCases {
		b.Run(tc.name, func(b *testing.B) {
			var result string
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				result, _, _ = strings.Cut(tc.username, "@")
			}
			_ = result // Prevent compiler optimization
		})
	}
}
```

</details>