### PR TITLE
Add useUIDAsGroupName option to Azure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Groups contained within Azure Active Directory can be synchronized into OpenShif
 | `clientFilter` | CEL expression for client-side filtering of groups (See below) | | No |
 | `groups` | List of groups to filter against | | No |
 | `userNameAttributes` | Fields on a user record to use as the User Name | `userPrincipalName` | No |
-| `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group | `false` | No |
+| `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group (See below) | `false` | No |
 | `prune` | Prune Whether to prune groups that are no longer in Azure | `false` | No |
 
 The following is an example of a minimal configuration that can be applied to integrate with a Azure provider:
@@ -165,6 +165,29 @@ clientFilter: "group.createdDateTime > timestamp('2024-01-01T00:00:00Z')"
 ```
 
 **Performance Note:** The `filter` parameter uses server-side filtering (fast), while `clientFilter` applies after retrieving groups (slower for large result sets). For best performance, use `filter` to narrow down the result set, then use `clientFilter` for fine-grained control.
+
+#### Using the Object ID as the Group Name
+
+By default, the Azure `displayName` becomes the name of the OpenShift group. Setting `useUIDAsGroupName` to `true` uses the Azure group object ID instead, which yields a name that remains stable when a group is renamed in Azure and that matches the identifier used by systems referencing groups by object ID:
+
+```yaml
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GroupSync
+metadata:
+  name: azure-groupsync
+spec:
+  providers:
+  - name: azure
+    azure:
+      credentialsSecret:
+        name: azure-group-sync
+        namespace: group-sync-operator
+      useUIDAsGroupName: true
+```
+
+The `groups`, `filter` and `clientFilter` options continue to operate on the display name; only the resulting group name is affected. The display name remains available on the synchronized group as the `group-sync-operator.redhat-cop.io/sync.source.name` annotation.
+
+**Migration Note:** Because groups are matched by name, changing this setting on an existing installation causes the groups to be recreated under their new names. With `prune: true`, the groups carrying the previous names are removed on the next synchronization; with `prune: false`, they remain behind and have to be deleted manually.
 
 #### Authenticating to Azure
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Groups contained within Azure Active Directory can be synchronized into OpenShif
 | `clientFilter` | CEL expression for client-side filtering of groups (See below) | | No |
 | `groups` | List of groups to filter against | | No |
 | `userNameAttributes` | Fields on a user record to use as the User Name | `userPrincipalName` | No |
+| `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group | `false` | No |
 | `prune` | Prune Whether to prune groups that are no longer in Azure | `false` | No |
 
 The following is an example of a minimal configuration that can be applied to integrate with a Azure provider:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Groups contained within Azure Active Directory can be synchronized into OpenShif
 | `filter` | Graph API filter | | No |
 | `groups` | List of groups to filter against | | No |
 | `userNameAttributes` | Fields on a user record to use as the User Name | `userPrincipalName` | No |
+| `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group | `false` | No |
 | `prune` | Prune Whether to prune groups that are no longer in Azure | `false` | No |
 
 The following is an example of a minimal configuration that can be applied to integrate with a Azure provider:

--- a/api/v1alpha1/groupsync_types.go
+++ b/api/v1alpha1/groupsync_types.go
@@ -423,6 +423,11 @@ type AzureProvider struct {
 	// +kubebuilder:validation:Optional
 	UserNameAttributes *[]string `json:"userNameAttributes,omitempty"`
 
+	// UseUIDAsGroupName determines whether the Azure group object ID (UID) is used as the name of the OpenShift group instead of the display name. Default is false
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use UID as Group Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// +kubebuilder:validation:Optional
+	UseUIDAsGroupName bool `json:"useUIDAsGroupName,omitempty"`
+
 	// Prune Whether to prune groups that are no longer in Azure. Default is false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Prune",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/groupsync_types.go
+++ b/api/v1alpha1/groupsync_types.go
@@ -434,6 +434,11 @@ type AzureProvider struct {
 	// +kubebuilder:validation:Optional
 	UserNameAttributes *[]string `json:"userNameAttributes,omitempty"`
 
+	// UseUIDAsGroupName determines whether the Azure group object ID (UID) is used as the name of the OpenShift group instead of the display name. Default is false
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Use UID as Group Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	// +kubebuilder:validation:Optional
+	UseUIDAsGroupName bool `json:"useUIDAsGroupName,omitempty"`
+
 	// Prune Whether to prune groups that are no longer in Azure. Default is false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Prune",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
@@ -153,6 +153,9 @@ spec:
                           prune:
                             description: Prune Whether to prune groups that are no longer in Azure. Default is false
                             type: boolean
+                          useUIDAsGroupName:
+                            description: UseUIDAsGroupName determines whether the Azure group object ID (UID) is used as the name of the OpenShift group instead of the display name. Default is false
+                            type: boolean
                           userNameAttributes:
                             description: UserNameAttributes are the fields to consider on the User object containing the username
                             items:

--- a/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_groupsyncs.yaml
@@ -133,6 +133,9 @@ spec:
                           prune:
                             description: Prune Whether to prune groups that are no longer in Azure. Default is false
                             type: boolean
+                          useUIDAsGroupName:
+                            description: UseUIDAsGroupName determines whether the Azure group object ID (UID) is used as the name of the OpenShift group instead of the display name. Default is false
+                            type: boolean
                           userNameAttributes:
                             description: UserNameAttributes are the fields to consider on the User object containing the username
                             items:

--- a/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
@@ -167,6 +167,13 @@ spec:
         path: providers[0].azure.userNameAttributes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: UseUIDAsGroupName determines whether the Azure group object ID
+          (UID) is used as the name of the OpenShift group instead of the display
+          name. Default is false
+        displayName: Use UID as Group Name
+        path: providers[0].azure.useUIDAsGroupName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: GitHub represents the GitHub provider
         displayName: GitHub Provider
         path: providers[0].github
@@ -783,6 +790,7 @@ spec:
     | `filter` | Graph API filter | | No |
     | `groups` | List of groups to filter against | | No |
     | `userNameAttributes` | Fields on a user record to use as the User Name | `userPrincipalName` | No |
+    | `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group | `false` | No |
     | `prune` | Prune Whether to prune groups that are no longer in Azure | `false` | No |
 
     The following is an example of a minimal configuration that can be applied to integrate with a Azure provider:

--- a/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/group-sync-operator.clusterserviceversion.yaml
@@ -180,6 +180,13 @@ spec:
         path: providers[0].azure.userNameAttributes
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: UseUIDAsGroupName determines whether the Azure group object ID
+          (UID) is used as the name of the OpenShift group instead of the display
+          name. Default is false
+        displayName: Use UID as Group Name
+        path: providers[0].azure.useUIDAsGroupName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: GitHub represents the GitHub provider
         displayName: GitHub Provider
         path: providers[0].github
@@ -852,6 +859,7 @@ spec:
     | `clientFilter` | CEL expression for client-side filtering after retrieval (e.g. `group.securityEnabled && group.description == ""`) | | No |
     | `groups` | List of groups to filter against | | No |
     | `userNameAttributes` | Fields on a user record to use as the User Name | `userPrincipalName` | No |
+    | `useUIDAsGroupName` | Use the Azure group object ID (UID) instead of the display name as the name of the OpenShift group | `false` | No |
     | `prune` | Prune Whether to prune groups that are no longer in Azure | `false` | No |
 
     The following is an example of a minimal configuration that can be applied to integrate with a Azure provider:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,7 @@ const (
 	SyncSourceURL     = AnnotationBase + "/sync.source.url"
 	SyncSourceHost    = AnnotationBase + "/sync.source.host"
 	SyncSourceUID     = AnnotationBase + "/sync.source.uid"
+	SyncSourceName    = AnnotationBase + "/sync.source.name"
 	SyncProvider      = AnnotationBase + "/sync-provider"
 	HierarchyChildren = "hierarchy_children"
 	HierarchyParent   = "hierarchy_parent"

--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -414,10 +414,7 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 			continue
 		}
 
-		ocpGroupName := *groupName
-		if a.Provider.UseUIDAsGroupName {
-			ocpGroupName = *group.DirectoryObject.GetId()
-		}
+		ocpGroupName := a.resolveGroupName(group, *groupName)
 
 		ocpGroup := userv1.Group{
 			TypeMeta: v1.TypeMeta{
@@ -435,6 +432,11 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 		// Set Host Specific Details
 		ocpGroup.GetAnnotations()[constants.SyncSourceHost] = azureURL.Host
 		ocpGroup.GetAnnotations()[constants.SyncSourceUID] = *group.DirectoryObject.GetId()
+
+		// Retain the Azure display name whenever it is not used as the Group name
+		if ocpGroupName != *groupName {
+			ocpGroup.GetAnnotations()[constants.SyncSourceName] = *groupName
+		}
 
 		groupMembers, err := a.listGroupMembers(group.DirectoryObject.GetId())
 
@@ -457,6 +459,25 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 
 func (a *AzureSyncer) GetProviderName() string {
 	return a.Name
+}
+
+// resolveGroupName determines the name to assign to the OpenShift Group. The Azure
+// display name is used unless UseUIDAsGroupName is enabled, in which case the Azure
+// group object ID is used, providing a name that is stable across group renames.
+func (a *AzureSyncer) resolveGroupName(group graph.Group, displayName string) string {
+
+	if !a.Provider.UseUIDAsGroupName {
+		return displayName
+	}
+
+	groupID := group.GetId()
+
+	if groupID == nil {
+		azureLogger.Info(fmt.Sprintf("Warning: Falling back to displayName for Group record with empty id. Group: %s", displayName), "Provider", a.Name)
+		return displayName
+	}
+
+	return *groupID
 }
 
 func (a *AzureSyncer) listGroupMembers(groupID *string) ([]string, error) {

--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -342,13 +342,18 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 			continue
 		}
 
+		ocpGroupName := *groupName
+		if a.Provider.UseUIDAsGroupName {
+			ocpGroupName = *group.DirectoryObject.GetId()
+		}
+
 		ocpGroup := userv1.Group{
 			TypeMeta: v1.TypeMeta{
 				Kind:       "Group",
 				APIVersion: userv1.GroupVersion.String(),
 			},
 			ObjectMeta: v1.ObjectMeta{
-				Name:        *groupName,
+				Name:        ocpGroupName,
 				Annotations: map[string]string{},
 				Labels:      map[string]string{},
 			},

--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -414,13 +414,18 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 			continue
 		}
 
+		ocpGroupName := *groupName
+		if a.Provider.UseUIDAsGroupName {
+			ocpGroupName = *group.DirectoryObject.GetId()
+		}
+
 		ocpGroup := userv1.Group{
 			TypeMeta: v1.TypeMeta{
 				Kind:       "Group",
 				APIVersion: userv1.GroupVersion.String(),
 			},
 			ObjectMeta: v1.ObjectMeta{
-				Name:        *groupName,
+				Name:        ocpGroupName,
 				Annotations: map[string]string{},
 				Labels:      map[string]string{},
 			},

--- a/pkg/syncer/azure_test.go
+++ b/pkg/syncer/azure_test.go
@@ -318,3 +318,63 @@ func TestExtractGroupFieldsWithNilValues(t *testing.T) {
 		t.Errorf("mailNickname should be empty string when not set, got %v", mailNickname)
 	}
 }
+
+// TestResolveGroupName tests the naming of the OpenShift Group derived from an Azure group
+func TestResolveGroupName(t *testing.T) {
+	tests := []struct {
+		name              string
+		useUIDAsGroupName bool
+		group             graph.Group
+		expectedName      string
+	}{
+		{
+			name:              "display name used by default",
+			useUIDAsGroupName: false,
+			group: func() graph.Group {
+				g := graph.NewGroup()
+				g.SetDisplayName(strPtr("test-group"))
+				g.SetId(strPtr("8c4d1b3e-9d2a-4f61-8b0a-1f6c2d5e7a94"))
+				return *g
+			}(),
+			expectedName: "test-group",
+		},
+		{
+			name:              "object id used when enabled",
+			useUIDAsGroupName: true,
+			group: func() graph.Group {
+				g := graph.NewGroup()
+				g.SetDisplayName(strPtr("test-group"))
+				g.SetId(strPtr("8c4d1b3e-9d2a-4f61-8b0a-1f6c2d5e7a94"))
+				return *g
+			}(),
+			expectedName: "8c4d1b3e-9d2a-4f61-8b0a-1f6c2d5e7a94",
+		},
+		{
+			name:              "display name used as fallback when id is absent",
+			useUIDAsGroupName: true,
+			group: func() graph.Group {
+				g := graph.NewGroup()
+				g.SetDisplayName(strPtr("test-group"))
+				// id intentionally not set (nil)
+				return *g
+			}(),
+			expectedName: "test-group",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncer := &AzureSyncer{
+				Name: "azure",
+				Provider: &redhatcopv1alpha1.AzureProvider{
+					UseUIDAsGroupName: tt.useUIDAsGroupName,
+				},
+			}
+
+			groupName := syncer.resolveGroupName(tt.group, *tt.group.GetDisplayName())
+			if groupName != tt.expectedName {
+				t.Errorf("resolveGroupName() = %v, want %v", groupName, tt.expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an optional boolean field to the Azure provider that, when enabled, uses the Azure group object ID (UID) as the name of the synchronized OpenShift group instead of the display name. Group filtering (filter, groups, whitelist/blacklist) continues to match against the display name.

Motivation: We operate an authorization concept spanning multiple
systems that identifies groups by their Entra object ID (UID) rather
than by display name. This broke down once the first user was a member
of more than 200 groups, so the OpenShift groups need to be named by
UID to keep the mapping consistent across all systems.