### PR TITLE
Azure: match `groups`/`baseGroups` by object ID as well as display name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect

--- a/pkg/syncer/azure.go
+++ b/pkg/syncer/azure.go
@@ -37,6 +37,7 @@ import (
 	graph "github.com/microsoftgraph/msgraph-sdk-go/models"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
 )
 
 var (
@@ -233,7 +234,7 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 
 		for _, baseGroup := range a.Provider.BaseGroups {
 
-			filter := fmt.Sprintf("displayName eq '%s'", baseGroup)
+			filter := azureBaseGroupFilter(baseGroup)
 			groupRequestParameters := &msgroups.GroupsRequestBuilderGetQueryParameters{
 				Filter: &filter,
 			}
@@ -355,7 +356,10 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 			continue
 		}
 
-		if !isGroupAllowed(*groupName, a.Provider.Groups) {
+		// Match the configured groups filter against either the display name or
+		// the object ID. Azure display names are mutable and non-unique, so
+		// object IDs must be accepted as selectors as well.
+		if !azureGroupMatches(&group, a.Provider.Groups) {
 			continue
 		}
 
@@ -400,8 +404,43 @@ func (a *AzureSyncer) Sync() ([]userv1.Group, error) {
 
 	}
 
+	if len(a.Provider.Groups) > 0 && len(ocpGroups) == 0 {
+		azureLogger.Info("'groups' filter matched no Azure groups; verify the configured display names or object IDs",
+			"Provider", a.Name, "groups", a.Provider.Groups)
+	}
+
 	return ocpGroups, nil
 
+}
+
+// azureBaseGroupFilter builds the OData $filter used to resolve a configured
+// baseGroups entry. Azure group display names are neither unique nor stable, so
+// when the entry is a valid object ID (GUID) it is matched directly; otherwise
+// the display name is used. Note that "id eq '<value>'" with a non-GUID value is
+// rejected by Microsoft Graph (Request_BadRequest), so the two forms cannot be
+// combined into a single filter.
+func azureBaseGroupFilter(baseGroup string) string {
+	if _, err := uuid.Parse(baseGroup); err == nil {
+		return fmt.Sprintf("id eq '%s'", baseGroup)
+	}
+	return fmt.Sprintf("displayName eq '%s'", baseGroup)
+}
+
+// azureGroupMatches reports whether an Azure AD group satisfies the configured
+// groups filter. An empty filter matches everything. Both the display name and
+// the object ID are considered, so stable, unique object IDs may be used in
+// addition to (mutable, non-unique) display names.
+func azureGroupMatches(group graph.Groupable, allowedGroups []string) bool {
+	if len(allowedGroups) == 0 {
+		return true
+	}
+	if name := group.GetDisplayName(); name != nil && isGroupAllowed(*name, allowedGroups) {
+		return true
+	}
+	if id := group.GetId(); id != nil && isGroupAllowed(*id, allowedGroups) {
+		return true
+	}
+	return false
 }
 
 func (a *AzureSyncer) GetProviderName() string {
@@ -723,4 +762,3 @@ func (a *AzureSyncer) evaluateClientFilter(group graph.Group) (bool, error) {
 
 	return result, nil
 }
-

--- a/pkg/syncer/azure_test.go
+++ b/pkg/syncer/azure_test.go
@@ -318,3 +318,76 @@ func TestExtractGroupFieldsWithNilValues(t *testing.T) {
 		t.Errorf("mailNickname should be empty string when not set, got %v", mailNickname)
 	}
 }
+
+// TestAzureBaseGroupFilter verifies that a baseGroups entry is resolved by
+// object ID when it is a GUID and by display name otherwise. Combining both
+// into a single OData filter is not possible because "id eq '<non-guid>'" is
+// rejected by Microsoft Graph.
+func TestAzureBaseGroupFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		baseGroup string
+		expected  string
+	}{
+		{
+			name:      "object ID (GUID) is matched by id",
+			baseGroup: "b60f04c2-b6f3-4086-8570-059e7aa446bd",
+			expected:  "id eq 'b60f04c2-b6f3-4086-8570-059e7aa446bd'",
+		},
+		{
+			name:      "display name is matched by displayName",
+			baseGroup: "my-group",
+			expected:  "displayName eq 'my-group'",
+		},
+		{
+			name:      "non-ASCII display name is matched by displayName",
+			baseGroup: "グループ002",
+			expected:  "displayName eq 'グループ002'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := azureBaseGroupFilter(tt.baseGroup); got != tt.expected {
+				t.Errorf("azureBaseGroupFilter(%q) = %q, want %q", tt.baseGroup, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestAzureGroupMatches verifies that the groups filter matches on either the
+// display name or the object ID, and that an empty filter matches everything.
+func TestAzureGroupMatches(t *testing.T) {
+	newGroup := func(id, displayName string) graph.Groupable {
+		g := graph.NewGroup()
+		if id != "" {
+			g.SetId(strPtr(id))
+		}
+		if displayName != "" {
+			g.SetDisplayName(strPtr(displayName))
+		}
+		return g
+	}
+	guid := "b60f04c2-b6f3-4086-8570-059e7aa446bd"
+
+	tests := []struct {
+		name    string
+		group   graph.Groupable
+		allowed []string
+		want    bool
+	}{
+		{"empty filter allows any group", newGroup(guid, "team"), nil, true},
+		{"match by display name", newGroup(guid, "team"), []string{"team"}, true},
+		{"match by object ID", newGroup(guid, "team"), []string{guid}, true},
+		{"no match", newGroup(guid, "team"), []string{"other"}, false},
+		{"match by ID when display name differs", newGroup(guid, "renamed"), []string{guid}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := azureGroupMatches(tt.group, tt.allowed); got != tt.want {
+				t.Errorf("azureGroupMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The Azure provider's `groups` and `baseGroups` filters only match against a group's **display name**:

- `baseGroups` builds the Graph query `displayName eq '<value>'`
- `groups` filters enumerated groups client-side via `isGroupAllowed(displayName, ...)`

Azure AD group display names are mutable and not unique, so operators frequently configure the stable, unique **object ID (GUID)** instead. When an object ID is supplied today nothing matches and `Sync()` returns **0 groups, with no error and no warning** — the reconcile reports success and, with `prune: false`, any pre-existing group objects are left in place looking "synced", so the misconfiguration is effectively invisible.

## Change

- `groups` now matches an enumerated group by its **display name OR object ID**.
- `baseGroups` resolves each entry via `id eq '<guid>'` when it is a valid GUID and `displayName eq '<name>'` otherwise. The two forms cannot be merged into a single `displayName eq '…' or id eq '…'` filter, because `id eq '<non-guid>'` is rejected by Microsoft Graph with `Request_BadRequest`.
- A warning is logged when a non-empty `groups` filter matches nothing, so the misconfiguration is visible instead of silently succeeding.

All changes are backward compatible — existing display-name configuration keeps working unchanged.

## Testing

- `go build ./...`, `go vet ./pkg/syncer/`
- `go test ./pkg/syncer/` (existing suite + new tests pass)
- New unit tests: `TestAzureBaseGroupFilter`, `TestAzureGroupMatches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
