### PR TITLE
Adopt Groups whose GroupSync no longer exists

### DIFF
--- a/internal/controller/groupsync_controller.go
+++ b/internal/controller/groupsync_controller.go
@@ -95,6 +95,14 @@ func (r *GroupSyncReconciler) Reconcile(context context.Context, req ctrl.Reques
 		return r.ManageError(context, instance, err)
 	}
 
+	// Collect the names of all live GroupSync resources once per reconcile so
+	// that a Group whose recorded owner no longer exists (typically after a
+	// GroupSync was renamed) can be adopted instead of skipped forever
+	liveGroupSyncNames, err := r.liveGroupSyncNames(context)
+	if err != nil {
+		return r.ManageError(context, instance, err)
+	}
+
 	syncErrors := []error{}
 
 	// Execute Each Provider Syncer
@@ -154,9 +162,13 @@ func (r *GroupSyncReconciler) Reconcile(context context.Context, req ctrl.Reques
 				continue
 			} else {
 				// Verify this group is not managed by another provider
-				if groupProviderLabel, exists := ocpGroup.Labels[constants.SyncProvider]; !exists || (groupProviderLabel != providerLabel) {
+				groupProviderLabel, exists := ocpGroup.Labels[constants.SyncProvider]
+				if !shouldSyncExistingGroup(groupProviderLabel, exists, providerLabel, liveGroupSyncNames) {
 					r.Log.Info("Group Provider Label Did Not Match Expected Provider Label", "Provider", groupSyncer.GetProviderName(), "Group Name", ocpGroup.Name, "Expected Label", providerLabel, "Found Label", groupProviderLabel)
 					continue
+				}
+				if groupProviderLabel != providerLabel {
+					r.Log.Info("Adopting Group Whose GroupSync No Longer Exists", "Provider", groupSyncer.GetProviderName(), "Group Name", ocpGroup.Name, "New Label", providerLabel, "Previous Label", groupProviderLabel)
 				}
 			}
 
@@ -253,6 +265,54 @@ func (r *GroupSyncReconciler) manageSyncError(prometheusLabels prometheus.Labels
 
 	*syncErrors = append(*syncErrors, err)
 
+}
+
+// liveGroupSyncNames returns the names of all GroupSync resources currently
+// present in the cluster. Groups record only the GroupSync name in their
+// sync-provider label (not the namespace), so names are collected across all
+// namespaces: as long as any live GroupSync claims a name, Groups labeled with
+// that name are treated as owned and are never adopted.
+func (r *GroupSyncReconciler) liveGroupSyncNames(context context.Context) (map[string]bool, error) {
+
+	groupSyncList := &redhatcopv1alpha1.GroupSyncList{}
+	if err := r.GetClient().List(context, groupSyncList); err != nil {
+		return nil, err
+	}
+
+	names := make(map[string]bool, len(groupSyncList.Items))
+	for _, groupSync := range groupSyncList.Items {
+		names[groupSync.Name] = true
+	}
+
+	return names, nil
+}
+
+// shouldSyncExistingGroup decides whether the current reconcile may write to an
+// existing Group, based on the Group's sync-provider label. It answers true
+// when the label matches the provider label of the current reconcile, or when
+// the label names a GroupSync that no longer exists — the Group is orphaned
+// (typically by a GroupSync rename) and is adopted. A Group without the label
+// was never synced by this operator and is left alone, as is a Group whose
+// label names a live GroupSync (genuine contention).
+func shouldSyncExistingGroup(foundLabel string, labelExists bool, providerLabel string, liveGroupSyncNames map[string]bool) bool {
+
+	if !labelExists {
+		return false
+	}
+
+	if foundLabel == providerLabel {
+		return true
+	}
+
+	// The label format is "<groupsync-name>_<provider-name>". Kubernetes object
+	// names cannot contain an underscore, so the first underscore unambiguously
+	// terminates the GroupSync name even when the provider name contains one.
+	groupSyncName, _, found := strings.Cut(foundLabel, "_")
+	if !found || groupSyncName == "" {
+		return false
+	}
+
+	return !liveGroupSyncNames[groupSyncName]
 }
 
 func (r *GroupSyncReconciler) pruneGroups(context context.Context, instance *redhatcopv1alpha1.GroupSync, syncedGroups []userv1.Group, providerName, providerLabel string, logger logr.Logger) (int, error) {

--- a/internal/controller/groupsync_controller_test.go
+++ b/internal/controller/groupsync_controller_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"testing"
+)
+
+// TestShouldSyncExistingGroup tests the decision of whether an existing Group
+// may be written by the current reconcile, given its sync-provider label and
+// the set of live GroupSync names.
+func TestShouldSyncExistingGroup(t *testing.T) {
+	tests := []struct {
+		name               string
+		foundLabel         string
+		labelExists        bool
+		providerLabel      string
+		liveGroupSyncNames map[string]bool
+		expected           bool
+	}{
+		{
+			name:               "exact match - group owned by this reconcile",
+			foundLabel:         "cluster-config_ldap",
+			labelExists:        true,
+			providerLabel:      "cluster-config_ldap",
+			liveGroupSyncNames: map[string]bool{"cluster-config": true},
+			expected:           true,
+		},
+		{
+			name:               "mismatch and old owner absent - adopt orphan",
+			foundLabel:         "old-name_ldap",
+			labelExists:        true,
+			providerLabel:      "new-name_ldap",
+			liveGroupSyncNames: map[string]bool{"new-name": true},
+			expected:           true,
+		},
+		{
+			name:               "mismatch but old owner still live - contention, skip",
+			foundLabel:         "other-groupsync_ldap",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true, "other-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "two providers of the same live GroupSync - contention, skip",
+			foundLabel:         "my-groupsync_azure",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "label absent - unmanaged group, never adopt",
+			foundLabel:         "",
+			labelExists:        false,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "label value has no underscore - unparseable, skip",
+			foundLabel:         "not-a-provider-label",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "provider name contains underscore, exact match",
+			foundLabel:         "my-groupsync_ldap_primary",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap_primary",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           true,
+		},
+		{
+			name:               "provider name contains underscore, old owner absent - adopt",
+			foundLabel:         "old-name_ldap_primary",
+			labelExists:        true,
+			providerLabel:      "new-name_ldap_primary",
+			liveGroupSyncNames: map[string]bool{"new-name": true},
+			expected:           true,
+		},
+		{
+			name:               "provider name contains underscore, old owner still live - skip",
+			foundLabel:         "old-name_ldap_primary",
+			labelExists:        true,
+			providerLabel:      "new-name_ldap_primary",
+			liveGroupSyncNames: map[string]bool{"new-name": true, "old-name": true},
+			expected:           false,
+		},
+		{
+			name:               "empty label value - skip",
+			foundLabel:         "",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "empty groupsync name in label value - skip",
+			foundLabel:         "_ldap",
+			labelExists:        true,
+			providerLabel:      "my-groupsync_ldap",
+			liveGroupSyncNames: map[string]bool{"my-groupsync": true},
+			expected:           false,
+		},
+		{
+			name:               "no live GroupSyncs at all, mismatched label - adopt",
+			foundLabel:         "old-name_ldap",
+			labelExists:        true,
+			providerLabel:      "new-name_ldap",
+			liveGroupSyncNames: map[string]bool{},
+			expected:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSyncExistingGroup(tt.foundLabel, tt.labelExists, tt.providerLabel, tt.liveGroupSyncNames)
+			if result != tt.expected {
+				t.Errorf("shouldSyncExistingGroup(%q, %v, %q, %v) = %v, want %v", tt.foundLabel, tt.labelExists, tt.providerLabel, tt.liveGroupSyncNames, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Renaming a `GroupSync` CR permanently orphans every Group it had synced: the Groups keep the old CR's name in
their `sync-provider` label, the renamed CR skips them on every reconcile, and the sync still reports success.

Fixes #466 — that issue has the full diagnosis, a reproduction, and a validation run.

## The change

`internal/controller/groupsync_controller.go:155-161` refuses any existing Group whose `sync-provider` label
does not equal this reconcile's label. Because the label is built from the CR name (line 108), a rename makes
every previously-synced Group look like it belongs to another provider, so `continue` fires three lines before
the code that would have corrected the label (178) and the timestamp (182). The skip logs at `Info` and is
never appended to `syncErrors`, so `ManageSuccess` still stamps `LastSyncSuccessTime`.

The guard's contention protection is worth keeping — what it cannot do is tell contention apart from
abandonment. This distinguishes them:

| existing Group's label | decision | why |
|---|---|---|
| equals this reconcile's label | sync (unchanged) | it is ours |
| names a **live** `GroupSync` | skip (unchanged) | genuine contention, including two providers of the same CR |
| absent entirely | skip (unchanged) | never synced by this operator; adopting would take over a hand-made Group |
| unparseable | skip | not a value this operator wrote |
| names a `GroupSync` that **no longer exists** | **adopt** | nothing can ever reclaim it |

Nothing downstream changes: the existing write path already sets the label, refreshes `sync-time`, merges
provider metadata without pruning user keys, and records the UID so same-pass pruning cannot remove the
adopted Group.

The decision is a pure function, so it is unit-testable without envtest — 12 table-driven cases covering exact
match, adoption, contention with a live owner, an absent label, an unparseable value, an empty CR-name part, a
provider name containing an underscore, and two providers of one live CR.

**Parsing the label is unambiguous.** A CR name is a DNS-1123 subdomain and cannot contain an underscore
(apiextensions-apiserver `NameIsDNSSubdomain`), while `spec.providers[].name` has no pattern validation and
may, so the **first** underscore always terminates the CR name. Legacy three-part labels from before `2be659b`
parse as CR name = the old namespace and are adopted unless a live CR bears that name — the desired outcome
either way.

**The live names are listed once per reconcile**, before the provider loop, served from the informer cache the
`For()` watch already maintains — no API round trip. **No RBAC change**: `list` on `groupsyncs` is already in
the marker at line 53 and in `config/rbac/role.yaml`.

## Verified on a cluster, not only in tests

OpenShift 4.18. The fix was built into an image, packaged as a bundle and a catalog, and installed through OLM
so it ran exactly as a release would.

Before, with v0.0.36 — a rename left 22 of 66 Groups stranded, and a forced sync did not touch them:

```
resourceVersion 29956737 -> 29956737   unchanged across a forced sync, so no Update was ever issued
sync-time frozen at the pre-rename value
"Group Provider Label Did Not Match Expected Provider Label"  x22 per sync, at Info
status.lastSyncSuccessTime advanced anyway; group_sync_error stayed 0
```

After, renaming A→B and then B→A:

```
19:34:42   21x "Group Provider Label Did Not Match"   <- CORRECT: helm creates the new CR before deleting the
                                                         old one, so the old owner was still live and the
                                                         contention guard held
19:39:58   21x "Adopting Group Whose GroupSync No Longer Exists"
19:47:36   21x adoptions again on the rename back (42 total)

sample Group   before: bdp-oud-group-rbac-groupsync_ldap | 19:34:39 | rv 30093707
               after : bdp-oud-rbac-groupsync_ldap       | 19:39:56 | rv 30096049
```

The `resourceVersion` **changing** is the point — same field, same command as the frozen one above.

Worth stating plainly: **adoption happens on the next reconcile after the old CR is gone**, not instantly. On
an hourly schedule that meant forcing a sync to observe it. The skips at 19:34:42 are kept in this report
rather than hidden, because they show the guard still refusing a Group whose owner is live.

Also checked, since a label alone proves little:

| check | result |
|---|---|
| Groups before / after | 66 / 66 |
| Groups whose label names a non-existent CR | 0 |
| `sync-time` on adopted Groups | advanced |
| RBAC bound to those Groups, by **UID** | unchanged — a count cannot see a delete-and-recreate |
| `oc auth can-i`, both directions | identical, including a read-only tier still denied `delete pods` |
| second forced sync | adopted 0 more — idempotent |

## Scope and limits

- Only the **LDAP** provider was exercised on the cluster. The change is provider-agnostic — nothing in any
  syncer reads `SyncProvider` back; it is written and consumed only in the controller — but I have not run the
  other six.
- Two cases deliberately keep today's behaviour: a label naming a live CR, and a Group with no label at all.
- If maintainers would prefer adoption to be opt-in behind a `spec` field, it is a single call site and easy
  to accommodate. I did not default it that way because the status quo it would preserve is not a behaviour
  anyone chose: a Group in this state is unreachable by every CR forever, invisible in status, and
  discoverable only by reading `Info` logs.
- Rejected alternatives, in case they come up: comparing only the provider suffix (deletes the contention
  protection and inverts the bug onto provider renames); keying off `SyncSourceHost`/`SyncSourceUID` or the
  LDAP url/uid annotations (only the LDAP syncer writes them, and they cannot distinguish a renamed CR from
  two CRs deliberately syncing the same subtree); and ownerReferences from Group to GroupSync (structurally
  invalid — a cluster-scoped `Group` naming a namespaced owner is unresolvable since v1.20, and it would
  garbage-collect synced Groups on CR deletion even with `prune: false`).
